### PR TITLE
Fix php 8.4 warning

### DIFF
--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -98,12 +98,12 @@ class ExportService
 
         // Write header
         if (!empty($csvData)) {
-            fputcsv($handle, array_keys($csvData[0]));
+            fputcsv($handle, array_keys($csvData[0]), ',', '"', '\\');
         }
 
         // Write data
         foreach ($csvData as $row) {
-            fputcsv($handle, $row);
+            fputcsv($handle, $row, ',', '"', '\\');
         }
 
         fclose($handle);


### PR DESCRIPTION
fputcsv(): the $escape parameter must be provided as its default value will change