### PR TITLE
fix: resolve TypeError by initializing Alpine filters in init()

### DIFF
--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -123,7 +123,7 @@
                     },
 
                     // Filter state
-                    filters: this.defaultFilters(),
+                    filters: {},
 
                     // Data
                     @if(config('activitylog-ui.features.saved_views', true))
@@ -147,6 +147,10 @@
                     // Initialization
                     async init() {
                         if (this.initialized) return;
+
+                        // init state
+                        this.filters = this.defaultFilters();
+                        
                         this.initialized = true;
 
                         @if(config('activitylog-ui.features.saved_views', true))


### PR DESCRIPTION
Fixed "this.defaultFilters is not a function" error in filterPanel component. 

The error occurred because `this` was being accessed during object property  definition, where the context refers to the global scope rather than the  component instance. Moved the assignment of the initial filter state into  the Alpine `init()` method to ensure correct 'this' binding.